### PR TITLE
pip install from git repo directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ A tool for enriching the output of `nvidia-smi`.
 ![CI](https://github.com/peci1/nvidia-htop/workflows/CI/badge.svg)
 
 # Install
-`pip3 install .`
+
+```bash
+pip install git+https://github.com/peci1/nvidia-htop.git
+```
 
 ## Usage
 


### PR DESCRIPTION
It is convenient because you do not need to clone the repo and then type `pip install .` Instead, you can directly pip install git repo.