### PR TITLE
Added the possibility to filter by GPU IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A tool for enriching the output of `nvidia-smi`.
                                        moderately used GPU, red - fully used GPU)
       -u|--user USER[,USER]            Limit the list of processes to selected users
                                        (comma-separated).
+      -i|--id ID[,ID]                  Limit the command to selected GPU IDs (comma-separated).
 
 Note: for backward compatibility, `nvidia-smi | nvidia-htop.py [-l [length]]` is also supported.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A tool for enriching the output of `nvidia-smi`.
                                        moderately used GPU, red - fully used GPU)
       -u|--user USER[,USER]            Limit the list of processes to selected users
                                        (comma-separated).
-      -i|--id ID[,ID]                  Limit the command to selected GPU IDs (comma-separated).
+      -i|--id ID[,ID[,ID]]             Limit the command to selected GPU IDs (comma-separated).
 
 Note: for backward compatibility, `nvidia-smi | nvidia-htop.py [-l [length]]` is also supported.
 

--- a/nvidia-htop.py
+++ b/nvidia-htop.py
@@ -3,7 +3,7 @@
 #######
 # USAGE
 #
-# [nvidia-smi | ] nvidia-htop.py [-l [length]]
+# [nvidia-smi | ] nvidia-htop.py [-l [length]] [-i ID]
 #   print GPU utilization with usernames and CPU stats for each GPU-utilizing process
 #
 #   -l|--command-length [length]     Print longer part of the commandline. If `length'
@@ -11,6 +11,7 @@
 #                                    otherwise print first 100 characters.
 #   -c|--color                       Colorize the output (green - free GPU, yellow -
 #                                    moderately used GPU, red - fully used GPU)
+#   -i|--id ID                       Limit the command to selected GPU IDs (comma-separated)
 ######
 
 import sys

--- a/nvidia-htop.py
+++ b/nvidia-htop.py
@@ -31,6 +31,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-l', '--command-length', default=20, const=100, type=int, nargs='?')
 parser.add_argument('-c', '--color', action='store_true')
 parser.add_argument('-u', '--user', default='', help="Limit the list of processes to selected users (comma-separated)")
+parser.add_argument('-i', '--id', default='', help="Limit the command to selected GPU IDs (comma-separated)")
 # only for testing
 parser.add_argument('-p', '--fake-ps', help="The list of processes to use instead of real output of `ps`")
 
@@ -54,7 +55,10 @@ if fake_stdin_path is not None:
 elif stdin_lines:
     lines = stdin_lines
 else:
-    ps_call = subprocess.run('nvidia-smi', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    nvidiasmi_args = []
+    if args.id is not None:
+        nvidiasmi_args = ['-i', args.id]
+    ps_call = subprocess.run(['nvidia-smi'] + nvidiasmi_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if ps_call.returncode != 0:
         print('nvidia-smi exited with error code {}:'.format(ps_call.returncode))
         print(ps_call.stdout.decode() + ps_call.stderr.decode())

--- a/nvidia-htop.py
+++ b/nvidia-htop.py
@@ -56,7 +56,7 @@ elif stdin_lines:
     lines = stdin_lines
 else:
     nvidiasmi_args = []
-    if args.id is not None:
+    if len(args.id) > 0:
         nvidiasmi_args = ['-i', args.id]
     ps_call = subprocess.run(['nvidia-smi'] + nvidiasmi_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if ps_call.returncode != 0:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -25,6 +25,10 @@ class TestNvidiaHtop(unittest.TestCase):
     def test_new_format_users(self):
         self.do_test('FAKE_STDIN_NEW_FORMAT', 'DESIRED_STDOUT_NEW_FORMAT_USERS', call_args=["-u", "root,test"])
 
+    # The --id option cannot be tested in this way. So we just check that the option is considered valid.
+    def test_new_format_filter_ids(self):
+        self.do_test('FAKE_STDIN_NEW_FORMAT', 'DESIRED_STDOUT_NEW_FORMAT', call_args=["-i", "1,2"])
+
     def test_long_pids(self):
         self.do_test('FAKE_STDIN_LONG_PIDS', 'DESIRED_STDOUT_LONG_PIDS', fake_ps='FAKE_PS_LONG_PIDS')
 


### PR DESCRIPTION
The standard nvidia-smi summary provides an option to display only some of the available GPUs. This feature is very useful in systems with many GPUs.

The standard nvidia-smi command is:
`nvidia-smi -i <comma-serparated-gpu-ids>`
For example, to display only GPU 1, 2 and 4:
`nvidia-smi -i 1,2,4`

I added the same exact `-i` argument, exploiting the nvidia-smi command directly. 

### Usage:
`nvidia-htop.py -i <comma-separated-gpu-ids>`

For example, to display only GPU 1, 2 and 4:
`nvidia-htop.py -i 1,2,4`

If a wrong ID list is passed, the command fails with the original nvidia-smi error message.
For example, asking for an non-existing GPU ID:
`nvidia-htop.py -i 42` or `nvidia-htop.py -i random,string`
Return:
`nvidia-smi exited with error code 6: No devices were found`

